### PR TITLE
Require class var annotations for class variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Custom flake8 rules
 * TUTOR300 - no expressions in the main body, unless under __name__ == "__main__", prevents global side effects
 * TUTOR400 - detect strings that were likely meant to be f-strings
 * TUTOR5
-    * TUTOR500 - instance variables set in `__init__` cannot overlap with class variables
+    * TUTOR500 (DEPRECATED: covered by 502/503 + mypy) - instance variables set in `__init__` cannot overlap with class variables
     * TUTOR501 - class variables must be defined before all functions
     * TUTOR502 - class variables must be type annotated
     * TUTOR503 - class variables must be annotated as class variables (except for dataclasses and named tuple)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Custom flake8 rules
 
 ## Rules
 
-* TUTOR100 - dataclass class variables require annotations
+* TUTOR100 (DEPRECATED, covered by 502) - dataclass class variables require annotations
     * Notes: you can trick this rule by renaming dataclass - and there is the potential for some false positives
 * TUTOR101 - dataclasses.dataclass cannot be renamed in import
     * Notes: this is meant to act against the major case of false negatives for TUTOR100
@@ -14,6 +14,8 @@ Custom flake8 rules
 * TUTOR5
     * TUTOR500 - instance variables set in `__init__` cannot overlap with class variables
     * TUTOR501 - class variables must be defined before all functions
+    * TUTOR502 - class variables must be type annotated
+    * TUTOR503 - class variables must be annotated as class variables (except for dataclasses and named tuple)
     * TUTOR510 - No two argument `super` within a class
 * TUTOR6
     * TUTOR610 - a function definition allows too many positional arguments (configurable with `max-definition-positional-args`)

--- a/tutor_flake/example_code/test_classvar_rules.py
+++ b/tutor_flake/example_code/test_classvar_rules.py
@@ -1,9 +1,17 @@
+import dataclasses
+from dataclasses import dataclass, field
+from typing import ClassVar, NamedTuple, TypeVar
+
+
 class DummyClass:
 
-    a: int = 4
-    b: float
-    c = "abc"
-    d = bool
+    a: int = 4  # noqa: TUTOR503
+    b: float  # noqa: TUTOR503
+    c = "abc"  # noqa: TUTOR502
+    d = bool  # noqa: TUTOR502
+    e: "str" = "abc"  # noqa: TUTOR503
+    f: ClassVar[bool] = False
+    g: ClassVar
 
     def __init__(self, value: float) -> None:
         self.a = 3  # noqa: TUTOR500
@@ -26,5 +34,41 @@ class DummyClass:
         # we allow this, but is still bad
         self.c = new_c
 
-    e: bool  # noqa: TUTOR501
-    f = 3  # noqa: TUTOR501
+    e: ClassVar[bool]  # noqa: TUTOR501
+    f = 3  # noqa: TUTOR501 TUTOR502
+
+
+class NT(NamedTuple):
+    bar: int
+
+
+@dataclass
+class ExampleDataclass:
+    a = 3  # noqa: TUTOR100
+    x: int
+    y: float
+    z = field(default=4)  # noqa: TUTOR100
+
+    Q = TypeVar("Q", bound="ExampleDataclass")
+
+    def method(self) -> None:
+        return None
+
+    def __str__(self) -> str:
+        return super().__str__()
+
+    @classmethod
+    def construct(cls) -> "ExampleDataclass":
+        raise NotImplementedError
+
+    # other inline comment
+
+
+@dataclasses.dataclass
+class Example2:
+    a = 3  # noqa: TUTOR100
+
+
+@dataclass(frozen=True)
+class Example3:
+    a = 4  # noqa: TUTOR100

--- a/tutor_flake/example_code/test_classvar_rules.py
+++ b/tutor_flake/example_code/test_classvar_rules.py
@@ -1,6 +1,6 @@
 import dataclasses
 from dataclasses import dataclass, field
-from typing import ClassVar, NamedTuple, TypeVar
+from typing import ClassVar, List, NamedTuple, TypeVar
 
 
 class DummyClass:
@@ -10,8 +10,9 @@ class DummyClass:
     c = "abc"  # noqa: TUTOR502
     d = bool  # noqa: TUTOR502
     e: "str" = "abc"  # noqa: TUTOR503
-    f: ClassVar[bool] = False
-    g: ClassVar
+    f: ClassVar
+    g: ClassVar[bool] = False
+    h: ClassVar[List[bool]]
 
     def __init__(self, value: float) -> None:
         self.a = 3  # noqa: TUTOR500
@@ -34,8 +35,8 @@ class DummyClass:
         # we allow this, but is still bad
         self.c = new_c
 
-    e: ClassVar[bool]  # noqa: TUTOR501
-    f = 3  # noqa: TUTOR501 TUTOR502
+    i: ClassVar[bool]  # noqa: TUTOR501
+    j = 3  # noqa: TUTOR501 TUTOR502
 
 
 class NT(NamedTuple):
@@ -44,10 +45,10 @@ class NT(NamedTuple):
 
 @dataclass
 class ExampleDataclass:
-    a = 3  # noqa: TUTOR100
+    a = 3  # noqa: TUTOR502
     x: int
     y: float
-    z = field(default=4)  # noqa: TUTOR100
+    z = field(default=4)  # noqa: TUTOR502
 
     Q = TypeVar("Q", bound="ExampleDataclass")
 
@@ -66,9 +67,9 @@ class ExampleDataclass:
 
 @dataclasses.dataclass
 class Example2:
-    a = 3  # noqa: TUTOR100
+    a = 3  # noqa: TUTOR502
 
 
 @dataclass(frozen=True)
 class Example3:
-    a = 4  # noqa: TUTOR100
+    a = 4  # noqa: TUTOR502

--- a/tutor_flake/example_code/test_dataclass_rules.py
+++ b/tutor_flake/example_code/test_dataclass_rules.py
@@ -1,44 +1,8 @@
 """
 isort:skip_file
 """
-import dataclasses
-from dataclasses import dataclass
+
 from dataclasses import dataclass as dc, field  # noqa: TUTOR101
-from typing import TypeVar  # noqa: TUTOR101
 
-
-@dataclass
-class ExampleDataclass:
-    a = 3  # noqa: TUTOR100
-    x: int
-    y: float
-    z = field(default=4)  # noqa: TUTOR100
-
-    Q = TypeVar("Q", bound="ExampleDataclass")
-
-    def method(self) -> None:
-        return None
-
-    def __str__(self) -> str:
-        return super().__str__()
-
-    @classmethod
-    def construct(cls) -> "ExampleDataclass":
-        raise NotImplementedError
-
-    # other inline comment
-
-
-@dataclasses.dataclass
-class Example2:
-    a = 3  # noqa: TUTOR100
-
-
-@dataclass(frozen=True)
-class Example3:
-    a = 4  # noqa: TUTOR100
-
-
-@dc
-class Example4:
-    a = 3
+if __name__ == "__main__":
+    dc, field

--- a/tutor_flake/plugin.py
+++ b/tutor_flake/plugin.py
@@ -4,15 +4,15 @@ from argparse import Namespace
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
-from typing import Any, Callable, Generator, Iterable, List, TypeVar
+from typing import Any, Callable, ClassVar, Generator, Iterable, List, TypeVar
 
 from flake8.options.manager import OptionManager
 
 from tutor_flake import __version__
 from tutor_flake.common import Flake8Error
 from tutor_flake.rules.asyncio import CreateTaskRequireName
-from tutor_flake.rules.classvar import ClassvarOrderingAndInstanceOverlap
-from tutor_flake.rules.dataclass import DataclassMissingAnnotations, DataclassRenamed
+from tutor_flake.rules.classvar import ClassvarCheck
+from tutor_flake.rules.dataclass import DataclassRenamed
 from tutor_flake.rules.no_sideeffects import NoSideeffects
 from tutor_flake.rules.os_path import (
     NoFromOSPathImports,
@@ -62,10 +62,10 @@ class TutorFlakeConfig:
 
 
 class TutorIntelligenceFlakePlugin:
-    name = "tutor_intelligence_custom_flake"
-    version = __version__
+    name: ClassVar[str] = "tutor_intelligence_custom_flake"
+    version: ClassVar[str] = __version__
 
-    config: TutorFlakeConfig
+    config: TutorFlakeConfig  # noqa: TUTOR503
 
     def __init__(self, tree: ast.AST) -> None:
         self._tree = tree
@@ -119,10 +119,7 @@ class CustomVisitor(ast.NodeVisitor):
 
     @visitor_decorator
     def visit_ClassDef(self, node: ast.ClassDef) -> Iterable[Flake8Error]:
-        return itertools.chain(
-            DataclassMissingAnnotations.check(node),
-            ClassvarOrderingAndInstanceOverlap.check(node),
-        )
+        return ClassvarCheck.check(node)
 
     @visitor_decorator
     def visit_Import(self, node: ast.Import) -> Iterable[Flake8Error]:

--- a/tutor_flake/rules/classvar.py
+++ b/tutor_flake/rules/classvar.py
@@ -1,8 +1,9 @@
 import ast
-from typing import Generator, List, Optional
+from typing import Generator
 
 from tutor_flake.common import (
     Flake8Error,
+    check_annotation,
     check_name_or_attribute,
     get_targets,
     is_type_var,
@@ -24,22 +25,17 @@ def is_named_tuple(node: ast.ClassDef) -> bool:
 
 
 class ClassvarCheck:
-    # confirms
     @classmethod
     def check(cls, node: ast.ClassDef) -> Generator[Flake8Error, None, None]:
-        class_variables: List[str] = []
-        init_function: Optional[ast.FunctionDef] = None
         function_seen = False
         for child in node.body:
             if isinstance(child, (ast.AnnAssign, ast.Assign)):
                 for target in get_targets(child):
-                    target_id: str = target.id  # type: ignore
-                    class_variables.append(target_id)
                     if function_seen:
                         yield Flake8Error.construct(
                             child,
                             "501",
-                            f"Class variable `{target_id}` instantiated after methods",
+                            f"Class variable `{target.id}` instantiated after methods",  # type: ignore
                             cls,
                         )
                 if not is_type_var(child.value):
@@ -51,38 +47,17 @@ class ClassvarCheck:
                             cls,
                         )
 
-                    elif not is_dataclass(node) and not is_named_tuple(node):
-                        if (
-                            not isinstance(
-                                annotation := child.annotation, ast.Subscript
-                            )
-                            or not isinstance(val := annotation.value, ast.Name)
-                            or not check_name_or_attribute(val, "ClassVar")
-                        ):  # TODO
-                            yield Flake8Error.construct(
-                                child,
-                                "503",
-                                "Class variable must be type annotated with `ClassVar`",
-                                cls,
-                            )
+                    elif (
+                        not is_dataclass(node)
+                        and not is_named_tuple(node)
+                        and not check_annotation(child, "ClassVar")
+                    ):
+                        yield Flake8Error.construct(
+                            child,
+                            "503",
+                            "Class variable must be type annotated with `ClassVar`",
+                            cls,
+                        )
 
             elif isinstance(child, ast.FunctionDef):
                 function_seen = True
-                if child.name == "__init__":
-                    init_function = child
-
-        if init_function is not None:
-            for module in ast.walk(init_function):
-                if isinstance(module, (ast.AnnAssign, ast.AugAssign, ast.Assign)):
-                    for target in get_targets(module):
-                        if (
-                            isinstance(target, ast.Attribute)
-                            and check_name_or_attribute(target.value, "self")
-                            and target.attr in class_variables
-                        ):
-                            yield Flake8Error.construct(
-                                target,
-                                "500",
-                                f"Instance variable `{target.attr}` overlaps with a class variable",
-                                cls,
-                            )

--- a/tutor_flake/rules/classvar.py
+++ b/tutor_flake/rules/classvar.py
@@ -1,10 +1,29 @@
 import ast
 from typing import Generator, List, Optional
 
-from tutor_flake.common import Flake8Error, check_name_or_attribute, get_targets
+from tutor_flake.common import (
+    Flake8Error,
+    check_name_or_attribute,
+    get_targets,
+    is_type_var,
+)
 
 
-class ClassvarOrderingAndInstanceOverlap:
+def is_dataclass(node: ast.ClassDef) -> bool:
+    for decorator in node.decorator_list:
+        if check_name_or_attribute(decorator, "dataclass") or (
+            isinstance(decorator, ast.Call)
+            and check_name_or_attribute(decorator.func, "dataclass")
+        ):
+            return True
+    return False
+
+
+def is_named_tuple(node: ast.ClassDef) -> bool:
+    return any(check_name_or_attribute(base, "NamedTuple") for base in node.bases)
+
+
+class ClassvarCheck:
     # confirms
     @classmethod
     def check(cls, node: ast.ClassDef) -> Generator[Flake8Error, None, None]:
@@ -23,7 +42,31 @@ class ClassvarOrderingAndInstanceOverlap:
                             f"Class variable `{target_id}` instantiated after methods",
                             cls,
                         )
-            if isinstance(child, ast.FunctionDef):
+                if not is_type_var(child.value):
+                    if isinstance(child, ast.Assign):
+                        yield Flake8Error.construct(
+                            child,
+                            "502",
+                            "Class variable must be type annotated",
+                            cls,
+                        )
+
+                    elif not is_dataclass(node) and not is_named_tuple(node):
+                        if (
+                            not isinstance(
+                                annotation := child.annotation, ast.Subscript
+                            )
+                            or not isinstance(val := annotation.value, ast.Name)
+                            or not check_name_or_attribute(val, "ClassVar")
+                        ):  # TODO
+                            yield Flake8Error.construct(
+                                child,
+                                "503",
+                                "Class variable must be type annotated with `ClassVar`",
+                                cls,
+                            )
+
+            elif isinstance(child, ast.FunctionDef):
                 function_seen = True
                 if child.name == "__init__":
                     init_function = child

--- a/tutor_flake/rules/dataclass.py
+++ b/tutor_flake/rules/dataclass.py
@@ -1,25 +1,7 @@
 import ast
 from typing import Generator
 
-from tutor_flake.common import Flake8Error, check_name_or_attribute, is_type_var
-
-
-class DataclassMissingAnnotations:
-    @classmethod
-    def check(cls, node: ast.ClassDef) -> Generator[Flake8Error, None, None]:
-        if is_dataclass(node):
-            for child in node.body:
-                if (
-                    isinstance(child, ast.Assign)
-                    and child.type_comment is None
-                    and not is_type_var(child.value)
-                ):
-                    yield Flake8Error.construct(
-                        child,
-                        "100",
-                        "Dataclass missing annotation for a class variable",
-                        cls,
-                    )
+from tutor_flake.common import Flake8Error
 
 
 class DataclassRenamed:
@@ -31,13 +13,3 @@ class DataclassRenamed:
                     yield Flake8Error.construct(
                         node, "101", "Dataclass renamed on import", cls
                     )
-
-
-def is_dataclass(node: ast.ClassDef) -> bool:
-    for decorator in node.decorator_list:
-        if check_name_or_attribute(decorator, "dataclass") or (
-            isinstance(decorator, ast.Call)
-            and check_name_or_attribute(decorator.func, "dataclass")
-        ):
-            return True
-    return False


### PR DESCRIPTION
# Description

This allows us to deprecate a couple rules (relating to mypy and duplicate class + instance variables)

# Checklist:

- [ ] I have documented any added rules in the README