### PR TITLE
feat: prevent time.time and suggest alternatives

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/ @jack-tutor

--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Custom flake8 rules
     * TUT700 - Prevent `os.path.<func>()` function calls
     * TUT710 - Prevent `from os import path`
     * TUT720 - Prevent `import os.path`
+* TUT8
+    * TUT800 - Prevent `time.time`
+        * Note: programmers often use `time.time` to extract time deltas in seconds, rather than actually fetching the numbers of seconds since the epoch.  This has tricky pitfalls, such as clock sync jumps and lack of monotonicity guarantees.
+    * TUT810 - Prevent `from time import time` (see TUT800)
 
 ## Future Ideas
 

--- a/tutor_flake/example_code/test_time_rules.py
+++ b/tutor_flake/example_code/test_time_rules.py
@@ -1,0 +1,6 @@
+import time
+from time import time as time_time  # noqa: TUT810
+
+if __name__ == "__main__":
+    time_time()
+    time.time()  # noqa: TUT800

--- a/tutor_flake/plugin.py
+++ b/tutor_flake/plugin.py
@@ -32,6 +32,7 @@ from tutor_flake.rules.positional_args import (
 )
 from tutor_flake.rules.string import NoBracketInString
 from tutor_flake.rules.super import NoTwoArgumentSuper
+from tutor_flake.rules.time import NoFromTimeTimeImports, NoTimeDotTime
 
 
 @dataclass
@@ -141,6 +142,7 @@ class CustomVisitor(ast.NodeVisitor):
         return itertools.chain(
             DataclassRenamed.check(node),
             NoFromOSPathImports.check(node),
+            NoFromTimeTimeImports.check(node),
         )
 
     @visitor_decorator
@@ -165,7 +167,10 @@ class CustomVisitor(ast.NodeVisitor):
 
     @visitor_decorator
     def visit_Attribute(self, node: ast.Attribute) -> Iterable[Flake8Error]:
-        return NoOSPathAttrs.check(node)
+        return itertools.chain(
+            NoOSPathAttrs.check(node),
+            NoTimeDotTime.check(node),
+        )
 
     @visitor_decorator
     def visit_AnnAssign(self, node: ast.AnnAssign) -> Iterable[Flake8Error]:

--- a/tutor_flake/rules/time.py
+++ b/tutor_flake/rules/time.py
@@ -23,13 +23,7 @@ class NoTimeDotTime:
 class NoFromTimeTimeImports:
     @classmethod
     def check(cls, node: ast.ImportFrom) -> Generator[Flake8Error, None, None]:
-        import_path_from_os_cond = node.module == "time" and any(
-            [name.name == "time" for name in node.names]
-        )
-        import_func_from_os_path_cond = (
-            isinstance(node.module, str) and "time.time" in node.module
-        )
-        if import_func_from_os_path_cond or import_path_from_os_cond:
+        if node.module == "time" and any([name.name == "time" for name in node.names]):
             yield Flake8Error.construct(
                 node,
                 "810",

--- a/tutor_flake/rules/time.py
+++ b/tutor_flake/rules/time.py
@@ -1,0 +1,38 @@
+import ast
+from typing import Generator
+
+from tutor_flake.common import Flake8Error
+
+
+class NoTimeDotTime:
+    @classmethod
+    def check(cls, attr: ast.Attribute) -> Generator[Flake8Error, None, None]:
+        if (
+            attr.attr == "time"
+            and isinstance(attr.value, ast.Name)
+            and attr.value.id == "time"
+        ):
+            yield Flake8Error.construct(
+                attr,
+                "800",
+                "time.time() can jump and is not monotonic: are you sure it is what you want?",
+                cls,
+            )
+
+
+class NoFromTimeTimeImports:
+    @classmethod
+    def check(cls, node: ast.ImportFrom) -> Generator[Flake8Error, None, None]:
+        import_path_from_os_cond = node.module == "time" and any(
+            [name.name == "time" for name in node.names]
+        )
+        import_func_from_os_path_cond = (
+            isinstance(node.module, str) and "time.time" in node.module
+        )
+        if import_func_from_os_path_cond or import_path_from_os_cond:
+            yield Flake8Error.construct(
+                node,
+                "810",
+                "time.time() can jump and is not monotonic: are you sure it is what you want?",
+                cls,
+            )


### PR DESCRIPTION
# Description

`time.time()` is not monotonic and can jump forward seconds at a time.  We should discourage it's use in the most common contexts: eg,

```python
start_time = time.time()
do_expensive_operation()
print(f"This took {time.time() - start_time}s") # a lie!
```

There will occasionally be correct usages, but looking at our code I think this is rare enough to be appropriate for a `noqa`.

# Checklist:

- [x] I have documented any added rules in the README