### PR TITLE
fix: max positional args in async function def

### DIFF
--- a/tutor_flake/example_code/test_positional_args.py
+++ b/tutor_flake/example_code/test_positional_args.py
@@ -2,6 +2,10 @@ def func_1(a: int, b: int, c: int, d: int, e: int = 3) -> int:  # noqa: TUT610
     pass
 
 
+async def afunc_1(a: int, b: int, c: int, d: int, e: int = 3) -> int:  # noqa: TUT610
+    pass
+
+
 def func_2(a: int, b: int, c: int, *, d: int) -> int:
     pass
 
@@ -39,3 +43,7 @@ b = func_1(0, 1, 2, 3, e=5)
 d = func_5(0)
 e = func_5(0, 1, 2, 3, c=4)
 f = func_5(0, 1, 2, 3, 4)  # noqa: TUT620
+
+
+async def g() -> None:
+    await afunc_1(0, 1, 2, 3, 4)  # noqa: TUT620

--- a/tutor_flake/plugin.py
+++ b/tutor_flake/plugin.py
@@ -202,7 +202,12 @@ class CustomVisitor(ast.NodeVisitor):
     def visit_AsyncFunctionDef(
         self, node: ast.AsyncFunctionDef
     ) -> Iterable[Flake8Error]:
-        return AsyncFunctionsAreAsynchronous.check(node)
+        return itertools.chain(
+            MaxPostionalArgsInFunctionDef.check(
+                node, self.config.max_definition_positional_args
+            ),
+            AsyncFunctionsAreAsynchronous.check(node),
+        )
 
     @visitor_decorator
     def visit_ExceptHandler(self, node: ast.ExceptHandler) -> Iterable[Flake8Error]:

--- a/tutor_flake/rules/positional_args.py
+++ b/tutor_flake/rules/positional_args.py
@@ -7,7 +7,7 @@ from tutor_flake.common import Flake8Error
 class MaxPostionalArgsInFunctionDef:
     @classmethod
     def check(
-        cls, func: ast.FunctionDef, max_positional: int
+        cls, func: ast.FunctionDef | ast.AsyncFunctionDef, max_positional: int
     ) -> Generator[Flake8Error, None, None]:
         num_pos_only = len(func.args.posonlyargs)
         num_args = len(func.args.args)
@@ -32,7 +32,7 @@ class MaxPostionalArgsInFunctionDef:
         return arg.arg in ("self", "cls")
 
     @staticmethod
-    def first_arg(func: ast.FunctionDef) -> Optional[ast.arg]:
+    def first_arg(func: ast.FunctionDef | ast.AsyncFunctionDef) -> Optional[ast.arg]:
         if len(func.args.posonlyargs) > 0:
             return func.args.posonlyargs[0]
         elif len(func.args.args) > 0:


### PR DESCRIPTION
# Description

Fix an oversight in the rule

# Checklist:

- [x] I have documented any added rules in the README