### PR TITLE
fix: Allow for function which have docstrings, but are also basic.

### DIFF
--- a/tutor_flake/example_code/test_async_rules.py
+++ b/tutor_flake/example_code/test_async_rules.py
@@ -53,6 +53,42 @@ async def immediate_return() -> Any:
     return 0
 
 
+async def raise_error_with_docstring() -> Any:
+    """
+    This is a docstring
+
+    Returns: Nothing
+    """
+    raise NotImplementedError()
+
+
+async def use_pass_with_docstring() -> Any:
+    """
+    This is a docstring
+
+    Returns: Nothing
+    """
+    pass
+
+
+async def use_dot_dot_dot_with_docstring() -> Any:
+    """
+    This is a docstring
+
+    Returns: Nothing
+    """
+    ...
+
+
+async def immediate_return_with_docstring() -> Any:
+    """
+    This is a docstring
+
+    Returns: Nothing
+    """
+    return 0
+
+
 async def no_await() -> Any:  # noqa: TUT210
     x = 4
     y = x + 3

--- a/tutor_flake/rules/asyncio.py
+++ b/tutor_flake/rules/asyncio.py
@@ -49,13 +49,25 @@ class AsyncFunctionsAreAsynchronous:
     @classmethod
     def is_basic(cls, node: ast.AsyncFunctionDef) -> bool:
         first_line = node.body[0]
-        return (
-            isinstance(first_line, ast.Raise)
-            or isinstance(first_line, ast.Pass)
-            or isinstance(first_line, ast.Return)
-            or (
+        if len(node.body) == 1:
+            return cls.is_basic_node(first_line)
+        else:
+            second_line = node.body[1]
+            return cls.is_basic_node(second_line) and (
                 isinstance(first_line, ast.Expr)
-                and isinstance(val := first_line.value, ast.Constant)
+                and isinstance(first_line.value, ast.Constant)
+                and first_line.value.value == ast.get_docstring(node, clean=False)
+            )
+
+    @classmethod
+    def is_basic_node(cls, statement: ast.stmt) -> bool:
+        return (
+            isinstance(statement, ast.Raise)
+            or isinstance(statement, ast.Pass)
+            or isinstance(statement, ast.Return)
+            or (
+                isinstance(statement, ast.Expr)
+                and isinstance(val := statement.value, ast.Constant)
                 and (val.value == Ellipsis)
             )
         )

--- a/tutor_flake/rules/asyncio.py
+++ b/tutor_flake/rules/asyncio.py
@@ -55,8 +55,8 @@ class AsyncFunctionsAreAsynchronous:
             second_line = node.body[1]
             return cls.is_basic_node(second_line) and (
                 isinstance(first_line, ast.Expr)
-                and isinstance(first_line.value, ast.Constant)
-                and first_line.value.value == ast.get_docstring(node, clean=False)
+                and isinstance(val := first_line.value, ast.Constant)
+                and val.value == ast.get_docstring(node, clean=False)
             )
 
     @classmethod


### PR DESCRIPTION
# Description

Fixes a specific case for TUT 210 in which functions which are "basic" and therefore are not subject to the rule, are falsely marked as violating the rule if they have a docstring. 

# Checklist:

- [x] I have documented any added rules in the README